### PR TITLE
Add TypeError as expected error for Colour creation in Embed

### DIFF
--- a/guilded/embed.py
+++ b/guilded/embed.py
@@ -131,7 +131,7 @@ class Embed:
 
         try:
             self._colour = Colour(value=data['color'])
-        except KeyError:
+        except (KeyError, TypeError):
             pass
 
         try:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/guilded/gateway.py", line 114, in received_event
    await event
  File "/usr/lib/python3.8/site-packages/guilded/gateway.py", line 188, in ChatMessageCreated
    message = Message(state=self.client.http, channel=channel, data=data, author=author, team=team)
  File "/usr/lib/python3.8/site-packages/guilded/message.py", line 68, in __init__
    self.content = self._get_full_content()
  File "/usr/lib/python3.8/site-packages/guilded/message.py", line 169, in _get_full_content
    self.embeds.append(Embed.from_dict(msg_embed))
  File "/usr/lib/python3.8/site-packages/guilded/embed.py", line 133, in from_dict
    self._colour = Colour(value=data['color'])
  File "/usr/lib/python3.8/site-packages/guilded/colour.py", line 28, in __init__
    raise TypeError('Expected int parameter, received %s instead.' % value.__class__.__name__)
TypeError: Expected int parameter, received NoneType instead
```