### PR TITLE
fix for ValueError in utils.ISO8601

### DIFF
--- a/guilded/utils.py
+++ b/guilded/utils.py
@@ -78,7 +78,7 @@ def ISO8601(string: str):
             return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
         except:
             # get rid of milliseconds since datetime.fromisoformat doesn't accept them
-            string = re.sub(r'\.\d{1,5}', '', string)
+            string = re.sub(r'\.\d{1,6}', '', string)
             try:
                 return datetime.datetime.fromisoformat(string)
             except:


### PR DESCRIPTION
`fromisoformat` was added to better deal with timestamps from datetime, but the default datetime timestamp has 6 spaces for milliseconds not 5. current version raises a `ValueError`.

i would also like to mention that `fromisoformat` does in fact accept milliseconds, but only the "proper" 6 and 3 digit representations. 
![YesItDoes](https://user-images.githubusercontent.com/42589471/133918786-fc6f59c2-d8ff-407a-bde5-44b749092a5f.PNG)
![3digit](https://user-images.githubusercontent.com/42589471/133918966-511972c3-42a9-482e-a9cb-a875b711b538.PNG)


also, despite the fact that i also used it here, millisecond isn't really the proper term for that section of numbers; the first 4 digits are milliseconds, but anything after in a normal timestamp would be referring to microseconds