### PR TITLE
Set required aiohttp version to be less than 4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setuptools.setup(
         'Natural Language :: English'
     ],
     python_requires='>=3.6',
-    install_requires=['aiohttp'],
+    install_requires=['aiohttp<4.0.0'],
 )


### PR DESCRIPTION
Version 4.0+ of aiohttp causes breakages in the Client connection. Probably best to just keep it below 4.0 for the time being