### PR TITLE
Fixed bug where flowbots weren't being identified as members

### DIFF
--- a/guilded/flowbot.py
+++ b/guilded/flowbot.py
@@ -65,8 +65,6 @@ class FlowBot:
         self.team_id: str = data.get('teamId')
 
         self.user_id: str = data.get('userId')
-        if self.member:
-            self.member._bot: bool = True
 
         self._author = extra.get('author')
         self.author_id: str = data.get('createdBy')

--- a/guilded/team.py
+++ b/guilded/team.py
@@ -245,6 +245,10 @@ class Team:
 
         for bot in data.get('bots', []) or data.get('webhooks', []):
             if bot.get('flows') is not None:
+                # Update member to bot if found within flowbots
+                member = self.get_member(bot.get('userId', ''))
+                if member:
+                    member._bot = True
                 bot = FlowBot(state=self._state, data=bot, team=self)
                 self._flowbots[bot.id] = bot
 


### PR DESCRIPTION
## Explanation
Came across a bug where Flowbots weren't being identified as bots. This is mostly an API issue, as retrieving a team's member list from `https://www.guilded.gg/api/teams/{teamid}/members` doesn't tag them as a bot for whatever reason.

The solution I came up with was to fix that later in the flowbot discovery section. Whether this is a good approach or not is debatable. The better option would be to request the API to be updated.

## Discovery
Was testing to see if bots could activate other bot's commands and it turned out they could
![image](https://user-images.githubusercontent.com/18319621/152707054-5c416bc7-fd51-4add-962f-f05dc3800068.png)
Root cause of the issue was found through that