### PR TITLE
Added fetch social link method

### DIFF
--- a/guilded/enums.py
+++ b/guilded/enums.py
@@ -63,6 +63,7 @@ __all__ = (
     'FlowTriggerType',
     'ServerType',
     'UserType',
+    'SocialLinkType',
     'RSVPStatus',
 )
 
@@ -330,6 +331,27 @@ class ServerType(Enum):
 class UserType(Enum):
     user = 'user'
     bot = 'bot'
+
+
+class SocialLinkType(Enum):
+    twitch = 'twitch'
+    bnet = 'bnet'
+    psn = 'psn'
+    xbox = 'xbox'
+    steam = 'steam'
+    origin = 'origin'
+    youtube = 'youtube'
+    twitter = 'twitter'
+    facebook = 'facebook'
+    switch = 'switch'
+    patreon = 'patreon'
+    roblox = 'roblox'
+    epic = 'epic'
+
+    # Aliases
+    battlenet = 'bnet'
+    playstation = 'psn'
+    epicgames = 'epic'
 
 
 class RSVPStatus(Enum):

--- a/guilded/http.py
+++ b/guilded/http.py
@@ -777,6 +777,9 @@ class HTTPClient(HTTPClientBase):
         }
         return self.request(Route('POST', f'/servers/{server_id}/roles/{role_id}/xp'), json=payload)
 
+    def get_member_social_link(self, server_id: str, user_id: str, social_link_type: str):
+        return self.request(Route('GET', f'/servers/{server_id}/members/{user_id}/social-links/{social_link_type}'))
+
     def ban_server_member(self, server_id: str, user_id: str, *, reason: str = None):
         payload = {}
         if reason is not None:

--- a/guilded/http.py
+++ b/guilded/http.py
@@ -777,9 +777,6 @@ class HTTPClient(HTTPClientBase):
         }
         return self.request(Route('POST', f'/servers/{server_id}/roles/{role_id}/xp'), json=payload)
 
-    def get_member_social_link(self, server_id: str, user_id: str, social_link_type: str):
-        return self.request(Route('GET', f'/servers/{server_id}/members/{user_id}/social-links/{social_link_type}'))
-
     def ban_server_member(self, server_id: str, user_id: str, *, reason: str = None):
         payload = {}
         if reason is not None:

--- a/guilded/types/social_link.py
+++ b/guilded/types/social_link.py
@@ -1,0 +1,33 @@
+"""
+MIT License
+
+Copyright (c) 2020-present shay (shayypy)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import annotations
+from typing import TypedDict
+from typing_extensions import NotRequired
+
+
+class SocialLink(TypedDict):
+    handle: NotRequired[str]
+    serviceId: NotRequired[str]
+    type: str

--- a/guilded/user.py
+++ b/guilded/user.py
@@ -55,7 +55,7 @@ import datetime
 import inspect
 import itertools
 from operator import attrgetter
-from typing import Any, List, Optional, TYPE_CHECKING, Set, Union
+from typing import Any, List, Dict, Optional, TYPE_CHECKING, Set, Union
 
 import guilded.abc
 
@@ -396,7 +396,7 @@ class Member(User):
         HTTPException
             Failed to edit this member.
         """
-        
+
         if nick is not MISSING:
             await self.set_nickname(nick)
 
@@ -508,6 +508,33 @@ class Member(User):
 
         data = await self._state.get_member_roles(self.server.id, self.id)
         return data['roleIds']
+
+    async def fetch_social_link(self, social_link_type: str) -> Dict[str, Optional[str]]:
+        """|coro|
+
+        Fetch the social link of this member.
+
+        Parameters
+        -----------
+        social_link_type: :class:`str`
+            The type of social link to fetch. This can be either "twitch", "patreon", "roblox", "twitter", or "steam".
+
+        Returns
+        --------
+        :class:`dict`
+            The data of the social link.
+
+        Raises
+        -------
+        NotFound
+            The member does not have the social link.
+        HTTPException
+            Failed to retrieve the social link.
+            The social link must be one of the allowed types.
+        """
+
+        data = await self._state.get_member_social_link(self.server.id, self.id, social_link_type)
+        return data['socialLink']
 
     async def award_xp(self, amount: int, /) -> int:
         """|coro|

--- a/guilded/user.py
+++ b/guilded/user.py
@@ -533,7 +533,7 @@ class Member(User):
             The social link must be one of the allowed types.
         """
 
-        data = await self._state.get_member_social_link(self.server.id, self.id, social_link_type)
+        data = await self._state.get_member_social_links(self.server.id, self.id, social_link_type)
         return data['socialLink']
 
     async def award_xp(self, amount: int, /) -> int:


### PR DESCRIPTION
Adds an additional method to the Member: `member.fetch_social_link(type)`  to retrieve the social link.

Note: I couldn't figure out the battle.net social link name, and it's not documented in the Guilded docs. I tried both battle.net and battle.