### PR TITLE
docs(embed): change Discord to Guilded

### DIFF
--- a/guilded/embed.py
+++ b/guilded/embed.py
@@ -85,7 +85,7 @@ class EmbedProxy:
 
 
 class Embed:
-    """Represents a Discord embed.
+    """Represents a Guilded chat embed.
 
     .. container:: operations
 


### PR DESCRIPTION
This fixes the docstring for ``guilded.Embed``. It currently says that it represents a Discord embed, which is incorrect. This PR fixes that.