### PR TITLE
Remove fetch_guilds/fetch_servers method from discordpy changes docs.

### DIFF
--- a/docs/discordpy.rst
+++ b/docs/discordpy.rst
@@ -35,6 +35,7 @@ Modified
   :attr:`.Webhook.server_id` to be filled or for you to provide the ``server``
   parameter to the respective method.
 * :meth:`.Client.fetch_invite` does not accept URLs or vanity codes.
+* :meth:`.Client.fetch_servers` returns a list of :class:`.Server` instead of an async iterator.
 
 Not present
 ~~~~~~~~~~~~
@@ -48,6 +49,7 @@ Not present
 * ``Client.create_dm``
 * ``Client.create_guild`` (``create_server``)
 * ``Client.delete_invite``
+* ``Client.fetch_guilds``
 * ``Client.fetch_premium_sticker_packs``
 * ``Client.fetch_stage_instance``
 * ``Client.fetch_sticker``

--- a/docs/discordpy.rst
+++ b/docs/discordpy.rst
@@ -48,7 +48,6 @@ Not present
 * ``Client.create_dm``
 * ``Client.create_guild`` (``create_server``)
 * ``Client.delete_invite``
-* ``Client.fetch_guilds`` (``fetch_servers``)
 * ``Client.fetch_premium_sticker_packs``
 * ``Client.fetch_stage_instance``
 * ``Client.fetch_sticker``


### PR DESCRIPTION
![image](https://github.com/shayypy/guilded.py/assets/103061664/b513ec72-7d21-44cf-83e5-2cc7d99f516a)
The `Client.fetch_servers()` method is now available in the Guilded API, and should not be listed as "Not present".