### PR TITLE
fix List[:class:`Servers`] in Client.fetch_servers()

### DIFF
--- a/guilded/client.py
+++ b/guilded/client.py
@@ -659,13 +659,14 @@ class Client:
     async def fetch_servers(self) -> List[Server]:
         """|coro|
 
+
         Fetch your list of servers from the API.
 
         .. versionadded:: 1.8
 
         Returns
         --------
-        List[:class:`.Servers`]
+        List[:class:`.Server`]
             The servers you are a member of.
         """
 

--- a/guilded/client.py
+++ b/guilded/client.py
@@ -659,7 +659,6 @@ class Client:
     async def fetch_servers(self) -> List[Server]:
         """|coro|
 
-
         Fetch your list of servers from the API.
 
         .. versionadded:: 1.8


### PR DESCRIPTION
List[:class:`Servers`] should be List[:class:`Server`] without the extra s.